### PR TITLE
Bump release for a new xapi release

### DIFF
--- a/SPECS/xcp-featured.spec
+++ b/SPECS/xcp-featured.spec
@@ -1,6 +1,6 @@
 Name:           xcp-featured
 Version:        1.1.8
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        XCP-ng feature daemon
 Group:          System/Hypervisor
 License:        ISC
@@ -44,6 +44,9 @@ ln -s /opt/xensource/libexec/xcp-featured %{buildroot}/opt/xensource/libexec/v6d
 %{_unitdir}/v6d.service
 
 %changelog
+* Mon Feb 02 2026 Pau Ruiz Safont <pr.safont@vates.tech> - 1.1.8-4
+- Rebuild for XAPI 26.0.0-1.1
+
 * Mon Nov 24 2025 Pau Ruiz Safont <pr.safont@vates.tech> - 1.1.8-3
 - Rebuild for xapi-25.33.1-2.1.xcpng8.3
 

--- a/SPECS/xcp-featured.spec
+++ b/SPECS/xcp-featured.spec
@@ -1,6 +1,6 @@
 Name:           xcp-featured
 Version:        1.1.8
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        XCP-ng feature daemon
 Group:          System/Hypervisor
 License:        ISC
@@ -44,6 +44,9 @@ ln -s /opt/xensource/libexec/xcp-featured %{buildroot}/opt/xensource/libexec/v6d
 %{_unitdir}/v6d.service
 
 %changelog
+* Thu Feb 18 2026 Pau Ruiz Safont <pr.safont@vates.tech> - 1.1.8-5
+- Rebuild with XAPI 26.1.3-1.1
+
 * Mon Feb 02 2026 Pau Ruiz Safont <pr.safont@vates.tech> - 1.1.8-4
 - Rebuild for XAPI 26.0.0-1.1
 


### PR DESCRIPTION
No code changes, only a bump of version to force a new build because its static build-dependencies have changed

Build: https://koji.xcp-ng.org/buildinfo?buildID=4667