### PR TITLE
v6d.service: Include as part of toolstack.target restarts

### DIFF
--- a/SOURCES/v6d.service
+++ b/SOURCES/v6d.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=XCP-ng feature daemon
-After=syslog.target
-Wants=syslog.target
+After=message-switch.service syslog.target
+Wants=message-switch.service syslog.target
+PartOf=toolstack.target
 
 [Service]
 Type=notify


### PR DESCRIPTION
### Main information

#### Context & Motivation

Without PartOf=toolstack.target, v6d wouldn't be restarted as part of xe-toolstack-restart.

Add message-switch as a dependency as well, mirroring the rest of toolstack services.

#### Release Target

- [ ] We already defined a release target with the release team.
- [X] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

8.3-next

---

### Release Notes and Documentation

#### Explain the change to users

Fix xcp-featured not being restarted as part of xe-toolstack-restart.

_Does this have any user-facing consequences though?_

#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Checked if the service is successfully restarted with `xe-toolstack-restart`.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

TODO

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

TODO

#### What tests have been or will be added to CI for this change? If none, explain why.

None

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
