### PR TITLE
Update to version 1.2.0

### DIFF
--- a/SOURCES/v6d.service
+++ b/SOURCES/v6d.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=XCP-ng feature daemon
-After=syslog.target
-Wants=syslog.target
+After=message-switch.service syslog.target
+Wants=message-switch.service syslog.target
+PartOf=toolstack.target
 
 [Service]
 Type=notify

--- a/SOURCES/xcp-featured-1.1.8.tar.gz
+++ b/SOURCES/xcp-featured-1.1.8.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6af9f33dc3fbea137fed79674a009dcd70eb6cbd481b63089f3a9678c01afd25
-size 2378

--- a/SOURCES/xcp-featured-1.2.0.tar.gz
+++ b/SOURCES/xcp-featured-1.2.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:000283535c16c5a8825464d833a89fe450eb17764c5998280f1556b907a686ec
+size 4949

--- a/SPECS/xcp-featured.spec
+++ b/SPECS/xcp-featured.spec
@@ -53,7 +53,7 @@ ln -s /opt/xensource/libexec/xcp-featured %{buildroot}/opt/xensource/libexec/v6d
 * Fri Feb 20 2026 Philippe Coval <philippe.coval@vates.tech> - 1.1.8-6
 - Rebuild with XAPI 26.1.3-1.2 (with openssl-3)
 
-* Thu Feb 18 2026 Pau Ruiz Safont <pr.safont@vates.tech> - 1.1.8-5
+* Wed Feb 18 2026 Pau Ruiz Safont <pr.safont@vates.tech> - 1.1.8-5
 - Rebuild with XAPI 26.1.3-1.1
 
 * Mon Feb 02 2026 Pau Ruiz Safont <pr.safont@vates.tech> - 1.1.8-4

--- a/SPECS/xcp-featured.spec
+++ b/SPECS/xcp-featured.spec
@@ -1,6 +1,6 @@
 Name:           xcp-featured
-Version:        1.1.8
-Release:        6%{?dist}
+Version:        1.2.0
+Release:        1%{?dist}
 Summary:        XCP-ng feature daemon
 Group:          System/Hypervisor
 License:        ISC
@@ -23,6 +23,7 @@ available on an xcp-ng host.
 
 %build
 DESTDIR=%{buildroot} %{__make}
+%{__make} test
 
 %install
 DESTDIR=%{buildroot} LIBEXECDIR=/opt/xensource/libexec %{__make} install
@@ -44,6 +45,11 @@ ln -s /opt/xensource/libexec/xcp-featured %{buildroot}/opt/xensource/libexec/v6d
 %{_unitdir}/v6d.service
 
 %changelog
+* Mon Apr 20 2026 Pau Ruiz Safont <pr.safont@vates.tech> - 1.2.0-1
+- bin: fix unused variables
+- feature: experimental features
+- v6d is now restarted by `xe-toolstack-restart`
+
 * Fri Feb 20 2026 Philippe Coval <philippe.coval@vates.tech> - 1.1.8-6
 - Rebuild with XAPI 26.1.3-1.2 (with openssl-3)
 


### PR DESCRIPTION
#### Work Item Reference

XCPNG-3205

#### Related changes

This change is stacked on top of #13

It conflicts with #12, so a merge order needs to be defined, some possible outcomes:
- #13 is merged first, this PR needs to be rebased
- This PR is merged first, #13 should be closed without merging

#### Context & Motivation

This new version adds unit tests to test some properties about the features. For example, because there were 2 different sources for features (xapi and hardcoded features in featured code), they could be duplicated; now duplicates are forbidden.

This new version adds a new feature: experimental features. This controlled by a directory in the filesystem, and will allow us to test features that are deemed to unstable to enable for most of the users and let it develop until it's stable enough.

Now the version conforms to the dbv format expected by xapi, which is date-based.

Now `xe-toolstack-restart` restarts the daemon, this means that host-reboots aren't needed to apply new versions.

#### Release Target

- [x] We already defined a release target with the release team: 8.3-next+1

---

### Release Notes and Documentation

This is a foundational update, and, as such, there are no user-facing changes of note.

We may want to highlight that this enables xcp-ng to start developing experimental features while they are disabled for most of the users as something to strengthen stability while also pushing for quick development of features.

#### Attention points

None of note

#### Documentation update needed

- [x] No

### Testing and regression avoidance


#### What tests have you performed?

- Manually tested updating to new version: the `xe-toolstack-restart`, issue was discovered and fixed.

- The unit-tests are now run as part to the build, features duplication and the experimental feature code are covered by these tests.

- Made sure than on update the feature that was duplicated is retained (vtpm):
```
Apr 20 17:27:32 metavega xapi: [debug||106 /var/lib/xcp/xapi|host.set_license_params R:6b2800657cbe|audit] Host.set_license_params: host = '84c2accc-9163-4aea-8e47-65208b4f4809 (metavega)'; license_params = [ restrict_vswitch_controller=false, restrict_lab=false, restrict_stage=false, restrict_storagelink=false, restrict_storagelink_site_recovery=false, restrict_web_selfservice=false, restrict_web_selfservice_manager=false, restrict_hotfix_apply=false, restrict_export_resource_data=false, restrict_read_caching=false, restrict_cifs=false, restrict_health_check=false, restrict_xcm=false, restrict_vm_memory_introspection=false, restrict_batch_hotfix_apply=false, restrict_management_on_vlan=false, restrict_ws_proxy=false, restrict_cloud_management=false, restrict_nrpe=false, restrict_vlan=false, restrict_qos=false, restrict_pool_attached_storage=false, restrict_netapp=false, restrict_equalogic=false, restrict_pooling=false, enable_xha=true, restrict_marathon=false, restrict_email_alerting=false, restrict_historical_performance=false, restrict_wlb=false, restrict_rbac=false, restrict_dmc=false, restrict_checkpoint=false, restrict_cpu_masking=false, restrict_connection=false, platform_filter=false, regular_nag_dialog=false, restrict_vmpr=false, restrict_vmss=false, restrict_intellicache=false, restrict_gpu=false, restrict_dr=false, restrict_vif_locking=false, restrict_storage_xen_motion=false, restrict_vgpu=false, restrict_integrated_gpu_passthrough=false, restrict_vss=false, restrict_guest_agent_auto_update=false, restrict_pci_device_for_auto_update=false, restrict_xen_motion=false, restrict_guest_ip_setting=false, restrict_ad=false, restrict_nested_virt=false, restrict_live_patching=false, restrict_set_vcpus_number_live=false, restrict_pvs_proxy=false, restrict_igmp_snooping=false, restrict_rpu=false, restrict_pool_size=false, restrict_cbt=false, restrict_usb_passthrough=false, restrict_network_sriov=false, restrict_corosync=true, restrict_cluster_address=false, restrict_zstd_export=false, restrict_pool_secret_rotation=false, restrict_certificate_verification=false, restrict_updates=false, restrict_internal_repo_access=false, restrict_vtpm=false, restrict_vm_groups=false, restrict_vm_start=false, restrict_vm_appliance_start=false ]
```
Note that the vtpm feature is _not_ restricted (`restrict_vtpm=false`), and it only appears once. Compare with the previous version, which contains `restrict_vtpm=false` twice:
```
Apr 20 17:26:12 metavega xapi: [debug||108 /var/lib/xcp/xapi|host.set_license_params R:61c31f0c7fca|audit] Host.set_license_params: host = '84c2accc-9163-4aea-8e47-65208b4f4809 (metavega)'; license_params = [ restrict_vswitch_controller=false, restrict_lab=false, restrict_stage=false, restrict_storagelink=false, restrict_storagelink_site_recovery=false, restrict_web_selfservice=false, restrict_web_selfservice_manager=false, restrict_hotfix_apply=false, restrict_export_resource_data=false, restrict_read_caching=false, restrict_cifs=false, restrict_health_check=false, restrict_xcm=false, restrict_vm_memory_introspection=false, restrict_batch_hotfix_apply=false, restrict_management_on_vlan=false, restrict_ws_proxy=false, restrict_cloud_management=false, restrict_vtpm=false, restrict_nrpe=false, restrict_vlan=false, restrict_qos=false, restrict_pool_attached_storage=false, restrict_netapp=false, restrict_equalogic=false, restrict_pooling=false, enable_xha=true, restrict_marathon=false, restrict_email_alerting=false, restrict_historical_performance=false, restrict_wlb=false, restrict_rbac=false, restrict_dmc=false, restrict_checkpoint=false, restrict_cpu_masking=false, restrict_connection=false, platform_filter=false, regular_nag_dialog=false, restrict_vmpr=false, restrict_vmss=false, restrict_intellicache=false, restrict_gpu=false, restrict_dr=false, restrict_vif_locking=false, restrict_storage_xen_motion=false, restrict_vgpu=false, restrict_integrated_gpu_passthrough=false, restrict_vss=false, restrict_guest_agent_auto_update=false, restrict_pci_device_for_auto_update=false, restrict_xen_motion=false, restrict_guest_ip_setting=false, restrict_ad=false, restrict_nested_virt=false, restrict_live_patching=false, restrict_set_vcpus_number_live=false, restrict_pvs_proxy=false, restrict_igmp_snooping=false, restrict_rpu=false, restrict_pool_size=false, restrict_cbt=false, restrict_usb_passthrough=false, restrict_network_sriov=false, restrict_corosync=true, restrict_cluster_address=false, restrict_zstd_export=false, restrict_pool_secret_rotation=false, restrict_certificate_verification=false, restrict_updates=false, restrict_internal_repo_access=false, restrict_vtpm=false, restrict_vm_groups=false, restrict_vm_start=false, restrict_vm_appliance_start=false ]
```
 

#### What manual tests should be performed after the build, and by whom?

We might want to retest that `xe-toolstack-restart` works as expected, should be easy to check by running `systemctl status v6d` after running the restart command and verifying that the last time it was started matches with the time the restart was commanded.

#### What's covered by the xcp-ng-tests test suite?

This component is tested indirectly. If an update is catastrophic, it would be visible by failures on pool migration, vtpm and other features that are controlled by the daemon, which are part of the tests already.

#### What tests have been or will be added to CI for this change? If none, explain why.

The unit tests explained above have been added to the rpm build.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [x] No