### PR TITLE
Update to version 1.2.1

### DIFF
--- a/SOURCES/xcp-featured-1.2.0.tar.gz
+++ b/SOURCES/xcp-featured-1.2.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:000283535c16c5a8825464d833a89fe450eb17764c5998280f1556b907a686ec
-size 4949

--- a/SOURCES/xcp-featured-1.2.1.tar.gz
+++ b/SOURCES/xcp-featured-1.2.1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78349eccb02cace9be3d820cdacbb8931e356295419028e14d6729010aea75a7
+size 5178

--- a/SPECS/xcp-featured.spec
+++ b/SPECS/xcp-featured.spec
@@ -1,6 +1,6 @@
 Name:           xcp-featured
-Version:        1.2.0
-Release:        2%{?dist}
+Version:        1.2.1
+Release:        1%{?dist}
 Summary:        XCP-ng feature daemon
 Group:          System/Hypervisor
 License:        ISC
@@ -45,6 +45,9 @@ ln -s /opt/xensource/libexec/xcp-featured %{buildroot}/opt/xensource/libexec/v6d
 %{_unitdir}/v6d.service
 
 %changelog
+* Fri May 15 2026 Pau Ruiz Safont <pr.safont@vates.tech> - 1.2.1-1
+- v6: apply_edition returns the default edition now (XCPNG-3294)
+
 * Wed May 13 2026 Andrii Sultanov <andriy.sultanov@vates.tech> - 1.2.0-2
 - Rebuild with XAPI 26.1.4-3.1
 


### PR DESCRIPTION
XCPNG-3294

#### Context & Motivation

The last version introduced a regression on Pool.join, this new version changes the behavior back to the previous one and adds a regression test to avoid introducing it again.

#### Release Target

- [X] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

8.3-next

---

### Release Notes and Documentation

No notes needed, the regression was introduced in a version not released to users

---

### Testing and regression avoidance

A regression test has been added to the code and it's run as part of the unit tests while building the RPM.

Some basic operations in the internal end-to-end tests are failing due to the regression. This means that the fix can be easily verified by rerunning the test suites.

#### What manual tests should be performed after the build, and by whom?

No manual tests are needed

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No


Scratch build can be found at https://koji.xcp-ng.org/buildinfo?buildID=5618