### PR TITLE
Bump release to rebuild against new xapi

### DIFF
--- a/SPECS/xcp-featured.spec
+++ b/SPECS/xcp-featured.spec
@@ -1,6 +1,6 @@
 Name:           xcp-featured
 Version:        1.2.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        XCP-ng feature daemon
 Group:          System/Hypervisor
 License:        ISC
@@ -45,6 +45,9 @@ ln -s /opt/xensource/libexec/xcp-featured %{buildroot}/opt/xensource/libexec/v6d
 %{_unitdir}/v6d.service
 
 %changelog
+* Tue Jun 09 2026 Andrii Sultanov <andriy.sultanov@vates.tech> - 1.2.1-2
+- Rebuild with XAPI 26.1.11-1.1
+
 * Fri May 15 2026 Pau Ruiz Safont <pr.safont@vates.tech> - 1.2.1-1
 - v6: apply_edition returns the default edition now (XCPNG-3294)
 


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-3291

#### Related changes (optional)

https://github.com/xcp-ng-rpms/xapi/pull/134 should be merged and built first

#### Release Target

- [ ] We already defined a release target with the release team.
- [X] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

`8.3-next+1`

---

### Testing and regression avoidance

Regular CI is enough

#### What manual tests should be performed after the build, and by whom?

None

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [X] No
