### PR TITLE
Bump release to rebuild against new xapi

### DIFF
--- a/SPECS/xcp-featured.spec
+++ b/SPECS/xcp-featured.spec
@@ -1,6 +1,6 @@
 Name:           xcp-featured
 Version:        1.2.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        XCP-ng feature daemon
 Group:          System/Hypervisor
 License:        ISC
@@ -45,6 +45,9 @@ ln -s /opt/xensource/libexec/xcp-featured %{buildroot}/opt/xensource/libexec/v6d
 %{_unitdir}/v6d.service
 
 %changelog
+* Mon Jun 22 2026 Andrii Sultanov <andriy.sultanov@vates.tech> - 1.2.1-3
+- Rebuild with XAPI 26.1.12-1.1
+
 * Tue Jun 09 2026 Andrii Sultanov <andriy.sultanov@vates.tech> - 1.2.1-2
 - Rebuild with XAPI 26.1.11-1.1
 


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-3458

#### Related changes (optional)

https://github.com/xcp-ng-rpms/xapi/pull/137 should be merged and built first

#### Release Target

- [ ] We already defined a release target with the release team.
- [X] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

`8.3-next`

---

### Testing and regression avoidance

Regular CI is enough

#### What manual tests should be performed after the build, and by whom?

None

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No
